### PR TITLE
Updated instructions for building for QEmu

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,20 +46,20 @@ single application.
 # Build NodeOS for QEmu from scratch in three steps
 
 1. Download the project source code and build NodeOS for QEmu
+   Requires genext2fs. Install with `sudo apt-get install genext2fs`
 
     ```bash
     git clone git@github.com:NodeOS/NodeOS.git
     cd NodeOS
-    PLATFORM=qemu ./build
+    PLATFORM=qemu_32 npm install
     ```
 
 2. Pick some microwave pop-corn and go to see a movie. No, really, do it.
 3. Exec your fresh compiled NodeOS image
 
     ```bash
-    qemu-system-i386 --kernel barebones/bzImage --initrd initramfs/initramfs.cpio.gz -hda rootfs/rootfs.img -hdb usersfs/usersfs.img -enable-kvm -nographic -append "console=ttyS0 ROOT=/dev/sda USERS=/dev/sdb"
+    npm start
     ```
-
 
 # NodeOS on Docker
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Requires genext2fs. Install with `sudo apt-get install genext2fs`
     cd NodeOS
     PLATFORM=qemu_32 npm install
     ```
+To build for 64 bits, use `PLATFORM=qemu_64 npm install`
 
 2. Pick some microwave pop-corn and go to see a movie. No, really, do it.
 3. Exec your fresh compiled NodeOS image

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ single application.
 
 # Build NodeOS for QEmu from scratch in three steps
 
-1. Download the project source code and build NodeOS for QEmu
-   Requires genext2fs. Install with `sudo apt-get install genext2fs`
+Requires genext2fs. Install with `sudo apt-get install genext2fs`
+
+1. Download the project source code and build NodeOS for QEmu.
 
     ```bash
     git clone git@github.com:NodeOS/NodeOS.git


### PR DESCRIPTION
I updated the instructions for building NodeOS for QEmu.  

I created a gist at https://gist.github.com/zodern/ad74ab479c3016a88b58 on how to fix some of the build errors.  Can I add it as a wiki page and link to it in the README?