### PR TITLE
Add link in readme to wiki page for fixing build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ To build for 64 bits, use `PLATFORM=qemu_64 npm install`
     ```bash
     npm start
     ```
+    
++If you have an error when building or running NodeOS, take a look at [this page](https://github.com/NodeOS/NodeOS/wiki/Fixing-NodeOS-Build-Errors)
 
 # NodeOS on Docker
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To build for 64 bits, use `PLATFORM=qemu_64 npm install`
     npm start
     ```
     
-+If you have an error when building or running NodeOS, take a look at [this page](https://github.com/NodeOS/NodeOS/wiki/Fixing-NodeOS-Build-Errors)
+If you encounter an error when building NodeOS, take a look at [this page](https://github.com/NodeOS/NodeOS/wiki/Fixing-NodeOS-Build-Errors)
 
 # NodeOS on Docker
 


### PR DESCRIPTION
I created a wiki page at  https://github.com/NodeOS/NodeOS/wiki/Fixing-NodeOS-Build-Errors and added a link in the README to it.