### PR TITLE
Compile genext2fs as nodeos-userfs dependency

### DIFF
--- a/bin/install-dependencies
+++ b/bin/install-dependencies
@@ -35,3 +35,9 @@ apt-get install -qq -y genisoimage isolinux syslinux syslinux-efi xorriso
 
 # usersfs
 apt-get install -qq -y genext2fs
+
+# autoconf
+apt-get install -qq -y autoconf
+
+# automake
+apt-get install -qq -y automake

--- a/node_modules/nodeos-usersfs/package.json
+++ b/node_modules/nodeos-usersfs/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "install": "scripts/install",
+    "preinstall": "scripts/preinstall",
     "start": "scripts/start",
     "test": "scripts/test"
   },

--- a/node_modules/nodeos-usersfs/scripts/install
+++ b/node_modules/nodeos-usersfs/scripts/install
@@ -130,8 +130,10 @@ case $PLATFORM in
 
     $GENEXT2FS -b $((DISK_SIZE*1024)) \
         --root $OBJECTS              \
+        --block-size          1024   \
         --bytes-per-inode     4096   \
         --reserved-percentage    0   \
+        --creator-os linux           \
         --allow-holes                \
         --squash $OUT_DIR            || exit 41
 

--- a/node_modules/nodeos-usersfs/scripts/install
+++ b/node_modules/nodeos-usersfs/scripts/install
@@ -9,6 +9,8 @@ CLR="\e[0m"
 BAREBONES=`pwd`/../nodeos-barebones
 NODE_DIR=$BAREBONES/deps/node
 
+GENEXT2FS=`pwd`/deps/genext2fs/genext2fs
+
 TOOLCHAIN=$BAREBONES/node_modules/nodeos-cross-toolchain
 TOOLS=$TOOLCHAIN/out
 
@@ -126,12 +128,10 @@ case $PLATFORM in
 
     mkdir -p `dirname $OUT_DIR`
 
-    genext2fs -b $((DISK_SIZE*1024)) \
+    $GENEXT2FS -b $((DISK_SIZE*1024)) \
         --root $OBJECTS              \
-        --block-size          1024   \
         --bytes-per-inode     4096   \
         --reserved-percentage    0   \
-        --creator-os linux           \
         --allow-holes                \
         --squash $OUT_DIR            || exit 41
 

--- a/node_modules/nodeos-usersfs/scripts/preinstall
+++ b/node_modules/nodeos-usersfs/scripts/preinstall
@@ -20,8 +20,8 @@ if [[ ! -d $SRC_DIR ]]; then
   curl -L $GENEXT2FS_URL | tar xzf - -C $SRC_DIR --strip-components=1 || exit 10
 
   cd $SRC_DIR
-  ./autogen.sh
-  ./configure
+  $SRC_DIR/autogen.sh
+  $SRC_DIR/configure
   make
 
   echo -e "${GRN}Successfully compiled genext2fs${CLR}"

--- a/node_modules/nodeos-usersfs/scripts/preinstall
+++ b/node_modules/nodeos-usersfs/scripts/preinstall
@@ -7,7 +7,7 @@ GENEXT2FS_VERSION=1.4.1
 
 # Dependencies URLs
 
-GENEXT2FS_URL=http://downloads.sourceforge.net/project/genext2fs/genext2fs/1.4.1/genext2fs-1.4.1.tar.gz
+GENEXT2FS_URL=http://downloads.sourceforge.net/project/genext2fs/genext2fs/$GENEXT2FS_VERSION/genext2fs-$GENEXT2FS_VERSION.tar.gz
 
 #
 # genext2fs

--- a/node_modules/nodeos-usersfs/scripts/preinstall
+++ b/node_modules/nodeos-usersfs/scripts/preinstall
@@ -16,6 +16,7 @@ GENEXT2FS_URL=https://github.com/5paceManSpiff/genext2fs/archive/nodeos-$GENEXT2
 
 SRC_DIR=$DEPS/genext2fs
 if [[ ! -d $SRC_DIR ]]; then
+  echo -e "Downloading genext2fs"
   mkdir -p $SRC_DIR &&
   curl -L $GENEXT2FS_URL | tar xzf - -C $SRC_DIR --strip-components=1 || exit 10
 

--- a/node_modules/nodeos-usersfs/scripts/preinstall
+++ b/node_modules/nodeos-usersfs/scripts/preinstall
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+DEPS=`pwd`/deps
+
+# Dependencies versions
+GENEXT2FS_VERSION=1.4.1
+
+# Dependencies URLs
+
+GENEXT2FS_URL=http://downloads.sourceforge.net/project/genext2fs/genext2fs/1.4.1/genext2fs-1.4.1.tar.gz
+
+#
+# genext2fs
+#
+
+SRC_DIR=$DEPS/genext2fs
+if [[ ! -d $SRC_DIR ]]; then
+  mkdir -p $SRC_DIR &&
+  curl -L $GENEXT2FS_URL | tar xzf - -C $SRC_DIR --strip-components=1 || exit 10
+
+  cd $SRC_DIR
+  ./configure
+  make
+
+  echo -e "${GRN}Successfully compiled genext2fs${CLR}"
+fi
+

--- a/node_modules/nodeos-usersfs/scripts/preinstall
+++ b/node_modules/nodeos-usersfs/scripts/preinstall
@@ -3,11 +3,12 @@
 DEPS=`pwd`/deps
 
 # Dependencies versions
+
 GENEXT2FS_VERSION=1.4.1
 
 # Dependencies URLs
 
-GENEXT2FS_URL=http://downloads.sourceforge.net/project/genext2fs/genext2fs/$GENEXT2FS_VERSION/genext2fs-$GENEXT2FS_VERSION.tar.gz
+GENEXT2FS_URL=https://github.com/5paceManSpiff/genext2fs/archive/nodeos-$GENEXT2FS_VERSION.tar.gz
 
 #
 # genext2fs
@@ -19,6 +20,7 @@ if [[ ! -d $SRC_DIR ]]; then
   curl -L $GENEXT2FS_URL | tar xzf - -C $SRC_DIR --strip-components=1 || exit 10
 
   cd $SRC_DIR
+  ./autogen.sh
   ./configure
   make
 


### PR DESCRIPTION
This pull request downloads and compiles `genext2fs` as part of the nodeos-userfs `preinstall` script.  It fixed #113.