### PR TITLE
Fix for 2f94f54

### DIFF
--- a/node_modules/nodeos-barebones/package.json
+++ b/node_modules/nodeos-barebones/package.json
@@ -14,7 +14,6 @@
   "author": "Jesús Leganés Combarro \"piranna\"",
   "license": "MIT",
   "dependencies": {
-    "cpio2tar": "^0.0.1",
     "download-manager": "^0.0.15",
     "nodeos-cross-toolchain": "NodeOS/nodeos-cross-toolchain",
     "qemu": "nodeos/qemu#raspi"

--- a/node_modules/nodeos-barebones/scripts/build
+++ b/node_modules/nodeos-barebones/scripts/build
@@ -136,7 +136,7 @@ case $PLATFORM in
 
       mkdir -p $OUT_DIR                            &&
       $OBJ_DIR/usr/gen_init_cpio $OBJ_DIR/cpio.txt | \
-          cpio2tar > $OUT_DIR/barebones.tar        || exit 42
+        scripts/cpio2tar > $OUT_DIR/barebones.tar        || exit 42
 
       rm -f $OBJ_DIR/.config || exit 43
     fi

--- a/node_modules/nodeos-barebones/scripts/cpio2tar
+++ b/node_modules/nodeos-barebones/scripts/cpio2tar
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+var cpio = require('cpio-stream')
+var tar  = require('tar-stream')
+
+
+var extract = cpio.extract()
+var pack    = tar.pack()
+
+extract.on('entry', function(header, stream, callback)
+{
+  stream.pipe(pack.entry(header, callback))
+})
+
+extract.on('finish', pack.finalize.bind(pack))
+
+process.stdin.pipe(extract)
+pack.pipe(process.stdout)

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "minimist": "^1.2.0",
     "nodeos-cross-toolchain": "NodeOS/nodeos-cross-toolchain",
     "qemu": "nodeos/qemu#raspi",
-    "suppose": "^0.5.1"
+    "suppose": "^0.5.1",
+    "tar-stream": "piranna/tar-stream",
+    "cpio-stream": "1.2.3"
   },
   "devDependencies": {
     "publish-release": "piranna/publish-release"

--- a/scripts/dockerBuild
+++ b/scripts/dockerBuild
@@ -26,7 +26,7 @@ source $TOOLCHAIN/scripts/adjustEnvVars.sh || exit $?
   npm run dockerBuild              || exit 40
 ) &&
 (
-  docker build -t NodeOS .         || exit 50
+  docker build -t nodeos .         || exit 50
 ) || exit $?
 
 


### PR DESCRIPTION
I deleted the `cpio2tar` on my machine because it causes a `command not found` error.
In order to get it working again i added the `cpio2tar` script like it was before 2f94f54 and put the content of the `server.js` file from your `cpio2tar` module in it.
The only error i get is the `Operation not permitted` mentioned in here #227 (PR NodeOS/nodeos-mount-filesystems#5). 

I also changed the name for the docker image name/tag to `nodeos` because i got this strange bug, where docker is complaining that the input name is invalid

```bash
invalid value "NodeOS" for flag -t: Error parsing reference: "NodeOS" is not a valid repository/tag
```