### PR TITLE
Rename 'NodeOS' to 'nodeos' on dockerBuild

### DIFF
--- a/scripts/dockerBuild
+++ b/scripts/dockerBuild
@@ -22,7 +22,7 @@ source $TOOLCHAIN/scripts/adjustEnvVars.sh || exit $?
   npm run dockerBuild              || exit 30
 ) &&
 (
-  docker build -t NodeOS .         || exit 40
+  docker build -t nodeos .         || exit 40
 ) || exit $?
 
 


### PR DESCRIPTION
It seems that docker dont like uppercase names