### PR TITLE
Rename 'NodeOS' to 'nodeos' and set absolute path

### DIFF
--- a/scripts/docker
+++ b/scripts/docker
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
-IMAGE=NodeOS
-USERSFS=out/latest/usersfs
+IMAGE=nodeos
+USERSFS=/out/latest/usersfs
 
 docker run -it           \
     --cap-add SYS_ADMIN  \


### PR DESCRIPTION
Like in the other file (dockerBuild) we need to change the name to lowercase. And after this docker complains about absolute paths for this i put a slash infront of the userfs variable.

After this i get this error we already discussed #227: 

``` bash
λ philipp [~/Dokumente/NodeOS] at  master !?
→ npm run docker                                                                                          [e16936d]

> NodeOS@1.0.0-RC2 docker /home/philipp/Dokumente/NodeOS
> scripts/docker

mount procfs: Operation not permitted
mount devtmpfs: Operation not permitted
fs.js:1048
  return binding.symlink(preprocessSymlinkDestination(target, type, path),
                 ^

Error: EEXIST: file already exists, symlink '/proc/mounts' -> '/etc/mtab'
    at Error (native)
    at Object.fs.symlinkSync (fs.js:1048:18)
    at /lib/node_modules/nodeos-mount-filesystems/server.js:381:6
    at /lib/node_modules/nodeos-mount-filesystems/node_modules/mkdirp/index.js:48:26
    at FSReqWrap.oncomplete (fs.js:117:15)
/proc/sched_debug: Operation not permitted
/proc/timer_stats: Operation not permitted
/proc/kcore: Operation not permitted
/proc/sysrq-trigger: Operation not permitted
/proc/sys: Operation not permitted
/proc/irq: Operation not permitted
/proc/fs: Operation not permitted
/proc/bus: Operation not permitted
/proc/asound: Operation not permitted
/dev/console: Operation not permitted
/dev/shm: Operation not permitted
/etc/hosts: Operation not permitted
/etc/hostname: Operation not permitted
/etc/resolv.conf: Operation not permitted
/dev/sda: Operation not permitted
/dev/mqueue: Operation not permitted
/sys/fs/cgroup/blkio: Operation not permitted
/sys/fs/cgroup/cpuset: Operation not permitted
/sys/fs/cgroup/pids: Operation not permitted
/sys/fs/cgroup/freezer: Operation not permitted
/sys/fs/cgroup/devices: Operation not permitted
/sys/fs/cgroup/memory: Operation not permitted
/sys/fs/cgroup/net_cls: Operation not permitted
/sys/fs/cgroup/cpu,cpuacct: Operation not permitted
/sys/fs/cgroup/systemd: Operation not permitted
/sys/fs/cgroup: Operation not permitted
/sys: Operation not permitted
/dev/pts: Operation not permitted
/dev: Operation not permitted
/proc: Operation not permitted
/: Operation not permitted
termination: Operation not permitted

npm ERR! Linux 4.6.2-1-ARCH
npm ERR! argv "/home/philipp/.nvm/versions/node/v5.12.0/bin/node" "/home/philipp/.nvm/versions/node/v5.12.0/bin/npm" "run" "docker"
npm ERR! node v5.12.0
npm ERR! npm  v3.8.6
npm ERR! code ELIFECYCLE
npm ERR! NodeOS@1.0.0-RC2 docker: `scripts/docker`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the NodeOS@1.0.0-RC2 docker script 'scripts/docker'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the NodeOS package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     scripts/docker
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs NodeOS
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls NodeOS
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /home/philipp/Dokumente/NodeOS/npm-debug.log
```
