### PR TITLE
Build command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ build them from source code.
 I'm working on that.
 
 ```bash
-git clone git@github.com:NodeOS/NodeOS.git
+git clone https://github.com/NodeOS/NodeOS.git
 cd NodeOS
 PLATFORM=docker npm install
 ```


### PR DESCRIPTION
Fix error:

```bash
git clone git@github.com:NodeOS/NodeOS.git
Cloning into 'NodeOS'...
The authenticity of host 'github.com (192.30.253.112)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
RSA key fingerprint is MD5:16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
Are you sure you want to continue connecting (yes/no)? y
Please type 'yes' or 'no': yes
Warning: Permanently added 'github.com,192.30.253.112' (RSA) to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.
```