### PR TITLE
fix build each layer when cd command fails

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -9,10 +9,10 @@ source $TOOLCHAIN/scripts/adjustEnvVars.sh || exit $?
 # Build each layer up
 #
 
-( cd node_modules/nodeos-barebones ; npm run build ) &&
-( cd node_modules/nodeos-initramfs ; npm run build ) &&
-( cd node_modules/nodeos-rootfs    ; npm run build ) &&
-( cd node_modules/nodeos-usersfs   ; npm run build ) || err $?
+( cd node_modules/nodeos-barebones && npm run build ) &&
+( cd node_modules/nodeos-initramfs && npm run build ) &&
+( cd node_modules/nodeos-rootfs    && npm run build ) &&
+( cd node_modules/nodeos-usersfs   && npm run build ) || err $?
 
 
 #


### PR DESCRIPTION
Change to ``&&`` operator between ``cd node_module/<layer>`` and ``npm run build`` because if the cd command cannot navigate to node_module/\<layer\> folder the npm run build start a build of the NodeOS recursively and the cd command error is ignored.