### PR TITLE
Rename nodeos-rootfs to nodeos-bootfs

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -11,7 +11,7 @@ source $TOOLCHAIN/scripts/adjustEnvVars.sh || exit $?
 
 ( cd node_modules/nodeos-barebones && npm run build ) &&
 ( cd node_modules/nodeos-initramfs && npm run build ) &&
-( cd node_modules/nodeos-rootfs    && npm run build ) &&
+( cd node_modules/nodeos-bootfs    && npm run build ) &&
 ( cd node_modules/nodeos-usersfs   && npm run build ) || err $?
 
 
@@ -28,7 +28,7 @@ case $PLATFORM in
   ;;
 
   *_iso|*_img)
-    cp node_modules/nodeos-rootfs/out/latest $OUT_DIR/rootfs
+    cp node_modules/nodeos-bootfs/out/latest $OUT_DIR/rootfs
   ;;
 
   *)

--- a/scripts/dockerBuild
+++ b/scripts/dockerBuild
@@ -18,7 +18,7 @@ source $TOOLCHAIN/scripts/adjustEnvVars.sh || exit $?
   npm run dockerBuild              || exit 20
 ) &&
 (
-  cd node_modules/nodeos-rootfs    &&
+  cd node_modules/nodeos-bootfs    &&
   npm run dockerBuild              || exit 30
 ) &&
 (


### PR DESCRIPTION
Since rootfs was renamed to bootfs i got "nodeos-rootfs" not found in `node_modules` so i searched for the error and found this.
Im not entirlely sure if that were all the places where we need to rename it.