### PR TITLE
Prebuild QEmu script typo

### DIFF
--- a/resources/runners/qemu.sh
+++ b/resources/runners/qemu.sh
@@ -20,7 +20,7 @@ $QEMU                        \
   -m 256M                    \
   -redir tcp:50080::80       \
   -redir tcp:50443::443      \
-  --kernel keernel           \
+  --kernel kernel           \
   --initrd initramfs.cpio.gz \
   -hda     usersfs.img       \
   -append  "$APPEND"

--- a/resources/runners/qemu.sh
+++ b/resources/runners/qemu.sh
@@ -20,7 +20,7 @@ $QEMU                        \
   -m 256M                    \
   -redir tcp:50080::80       \
   -redir tcp:50443::443      \
-  --kernel kernel           \
+  --kernel kernel            \
   --initrd initramfs.cpio.gz \
   -hda     usersfs.img       \
   -append  "$APPEND"


### PR DESCRIPTION
This is a typo in the prebuilt for QEmu causing the error:
```
qemu: could not load kernel 'keernel': No such file or directory
```
This fixes the script. 