### PR TITLE
QEMU run.sh Windows compatability

### DIFF
--- a/resources/runners/qemu.sh
+++ b/resources/runners/qemu.sh
@@ -17,9 +17,14 @@ do
     shift
 done
 
-grep -q -e "vmx" -e "svm" /proc/cpuinfo
-if [ $? -eq 0 ]; then
-  QEMU="$QEMU -enable-kvm"
+# Check for hardware-virtualization support
+if [ "$(egrep -m 1 '^flags.*(vmx|svm)' /proc/cpuinfo)" ]
+then
+    echo ">>> KVM: ON "
+    export QEMU="qemu-system-x86_64 -M accel=kvm:tcg"
+else
+    echo ">>> KVM: OFF "
+    export QEMU="qemu-system-i386"
 fi
 
 $QEMU                        \


### PR DESCRIPTION
Using mingw (or even the bash that comes with git-scm), and the windows build of QEMU gets us right up to the point of running NodeOS, but the original `qemu.sh` script doesn't detect KVM in a way that allows Windows to launch it, instead complaining about no accelerator detected.

The below patch borrows from lrvick/airgap#3 