### PR TITLE
fix issue #379

### DIFF
--- a/bin/install-dependencies
+++ b/bin/install-dependencies
@@ -56,6 +56,7 @@ $PKGMGR install gcc git || exit 20
 $PKGMGR install bc || exit 21
 $PKGMGR install genisoimage mtools libc6-i386 libuuid1:i386 || exit 22
 $PKGMGR install libsdl1.2-dev || exit 30
+$PKGMGR install libfuse-dev || exit 911
 
 # Update Node.js to v6.x (npm3) from the NodeSource repository
 curl -sL $NODESOURCE | bash && $APT install nodejs || exit 40


### PR DESCRIPTION
This fixes the issue described in #379.
https://github.com/NodeOS/NodeOS/issues/379

It installs the stable version of libfuse-dev.
It works as a temporary fix, however the final solution rests with the fuse-bindings repository, issue: https://github.com/mafintosh/fuse-bindings/issues/63