### PR TITLE
Add npm to install-dependencies

### DIFF
--- a/bin/install-dependencies
+++ b/bin/install-dependencies
@@ -26,6 +26,7 @@ $PKGMGR cpio || exit 30                     # initramfs
 $PKGMGR autoconf automake || exit 40        # usersfs
 $PKGMGR sdl || exit 50                      # qemu
 $PKGMGR nodejs-lts-boron || exit 60         # nodejs
+$PKGMGR npm || exit 70         # npm
 
 ln -sf /usr/bin/python2 /usr/bin/python     # symlink to python 2
 npm config set python /usr/bin/python2      

--- a/bin/install-dependencies
+++ b/bin/install-dependencies
@@ -26,7 +26,7 @@ $PKGMGR cpio || exit 30                     # initramfs
 $PKGMGR autoconf automake || exit 40        # usersfs
 $PKGMGR sdl || exit 50                      # qemu
 $PKGMGR nodejs-lts-boron || exit 60         # nodejs
-$PKGMGR npm || exit 70         # npm
+$PKGMGR npm || exit 70                      # npm
 
 ln -sf /usr/bin/python2 /usr/bin/python     # symlink to python 2
 npm config set python /usr/bin/python2      


### PR DESCRIPTION
On my fresh arch installation npm was not installed by default.